### PR TITLE
PM-18: Add StateDelegateController

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -100,4 +100,6 @@ ManualIPAddress=
 +ClassRedirects=(OldName="/Script/ProjectMars.EconomyManager",NewName="/Script/ProjectMars.EconomyController")
 +PropertyRedirects=(OldName="/Script/ProjectMars.State.EconomyManager",NewName="/Script/ProjectMars.State.EconomyController")
 +PropertyRedirects=(OldName="/Script/ProjectMars.ProjectMarsPlayer.EconomyManager",NewName="/Script/ProjectMars.ProjectMarsPlayer.EconomyController")
++FunctionRedirects=(OldName="/Script/ProjectMars.MarsGameStateBase.SetDelegateManager",NewName="/Script/ProjectMars.MarsGameStateBase.SetDelegateController")
++FunctionRedirects=(OldName="/Script/ProjectMars.EconomyController.InitialiseEvents",NewName="/Script/ProjectMars.EconomyController.SubscribeToDelegateEvents")
 

--- a/Source/ProjectMars/Delegates/StateDelegateController.cpp
+++ b/Source/ProjectMars/Delegates/StateDelegateController.cpp
@@ -1,0 +1,8 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "StateDelegateController.h"
+
+UStateDelegateController::UStateDelegateController()
+{
+}

--- a/Source/ProjectMars/Delegates/StateDelegateController.h
+++ b/Source/ProjectMars/Delegates/StateDelegateController.h
@@ -1,0 +1,23 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "DelegateController.h"
+#include "StateDelegateController.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnStateMonthlyUpdate);
+
+/**
+ * 
+ */
+UCLASS()
+class PROJECTMARS_API UStateDelegateController : public UDelegateController
+{
+	GENERATED_BODY()
+
+public:
+	UStateDelegateController();
+	
+	FOnStateMonthlyUpdate OnStateMonthlyUpdate;
+};

--- a/Source/ProjectMars/Economy/EconomyController.cpp
+++ b/Source/ProjectMars/Economy/EconomyController.cpp
@@ -4,7 +4,8 @@
 #include "EconomyController.h"
 
 #include "FinanceCalculator.h"
-#include "ProjectMars/Delegates/DelegateController.h"
+#include "Logging/StructuredLog.h"
+#include "ProjectMars/Delegates/StateDelegateController.h"
 #include "ProjectMars/Economy/Data/EconomyData.h"
 
 UEconomyController::UEconomyController()
@@ -17,7 +18,9 @@ UEconomyController::UEconomyController()
 
 	// Maps
 	InitialiseMonetarySources();
-	InitialiseDelegateEvents();
+
+	// Events
+
 }
 
 FEconomyData* UEconomyController::GetEconomyData() const
@@ -60,6 +63,15 @@ void UEconomyController::UpdateTreasury()
 	// Calculate treasury
 	const int32 UpdatedTreasury = EconomyData->GetTreasury() + EconomyData->GetNetIncome();
 	EconomyData->SetTreasury(UpdatedTreasury);
+
+	UE_LOGFMT(LogTemp, Warning, "Treasury updated!");
+}
+
+void UEconomyController::SubscribeToDelegateEvents(UStateDelegateController* StateDelegateController)
+{
+	StateDelegateController->OnStateMonthlyUpdate.AddDynamic(this, &UEconomyController::UpdateTreasury);
+	
+	UE_LOGFMT(LogTemp, Warning, "Delegate manager is INITIALISED!");
 }
 
 // Initialises map of income sources with enum keys and values set to 0 by default
@@ -76,17 +88,6 @@ void UEconomyController::InitialiseMonetarySources()
 	{
 		ExpenseSources.Add(Type, 0);
 	}
-}
-
-void UEconomyController::InitialiseDelegateEvents()
-{
-	if (!DelegateController)
-	{
-		UE_LOG(LogTemp, Warning, TEXT("Delegate manager was null."));
-		return;
-	}
-	UE_LOG(LogTemp, Warning, TEXT("Delegate manager is INITIALISED!"));
-	DelegateController->OnMonthlyUpdate.AddDynamic(this, &UEconomyController::UpdateTreasury);
 }
 
 

--- a/Source/ProjectMars/Economy/EconomyController.h
+++ b/Source/ProjectMars/Economy/EconomyController.h
@@ -9,7 +9,7 @@
 struct FEconomyData;
 
 class UFinanceCalculator;
-class UDelegateController;
+class UStateDelegateController;
 
 UENUM()
 enum class EIncomeType : uint8
@@ -55,12 +55,12 @@ public:
 	UFUNCTION()
 	void UpdateTreasury();
 
+	UFUNCTION()
+	void SubscribeToDelegateEvents(UStateDelegateController* StateDelegateController);
+
 private:
 	UPROPERTY()
 	UFinanceCalculator* FinanceCalculator{ nullptr };
-
-	UPROPERTY()
-	UDelegateController* DelegateController { nullptr };
 
 	// Structs
 	FEconomyData* EconomyData{ nullptr };
@@ -74,7 +74,4 @@ private:
 	// Functions
 	UFUNCTION()
 	void InitialiseMonetarySources();
-
-	UFUNCTION()
-	void InitialiseDelegateEvents();
 };

--- a/Source/ProjectMars/Framework/MarsGameStateBase.cpp
+++ b/Source/ProjectMars/Framework/MarsGameStateBase.cpp
@@ -22,6 +22,10 @@ AMarsGameStateBase::AMarsGameStateBase()
 	PlayerManagerComponent = CreateDefaultSubobject<UPlayerManagerComponent>(TEXT("Player Manager Component"));
 
 	DelegateController = NewObject<UDelegateController>();
+
+	// TODO: Remove - this is here for testing purposes
+	UState* Rome = NewObject<UState>();
+	Rome->SetupDelegateEvents(DelegateController);
 }
 
 AProjectMarsPlayer* AMarsGameStateBase::GetPlayer()
@@ -53,7 +57,6 @@ void AMarsGameStateBase::BeginPlay()
 {
 	Super::BeginPlay();
 	UE_LOG(LogTemp, Error, TEXT("TEST VS CODE!"));
-	
 }
 
 void AMarsGameStateBase::Tick(float DeltaSeconds)
@@ -133,7 +136,7 @@ void AMarsGameStateBase::SetFactionManager(AFactionManager* FactionMan)
     FactionManager = FactionMan;
 }
 
-void AMarsGameStateBase::SetDelegateManager(UDelegateController* DelegateControllerVar)
+void AMarsGameStateBase::SetDelegateController(UDelegateController* DelegateControllerVar)
 {
 	DelegateController = DelegateControllerVar;
 }

--- a/Source/ProjectMars/Framework/MarsGameStateBase.h
+++ b/Source/ProjectMars/Framework/MarsGameStateBase.h
@@ -54,7 +54,7 @@ public:
 	void SetFactionManager(AFactionManager* FactionMan);
 
 	UFUNCTION()
-	void SetDelegateManager(UDelegateController* ptr);
+	void SetDelegateController(UDelegateController* ptr);
 
 	UFUNCTION()
 	class UPlayerManagerComponent* GetPlayerManagerComponent() const;

--- a/Source/ProjectMars/Nation/State.cpp
+++ b/Source/ProjectMars/Nation/State.cpp
@@ -3,12 +3,23 @@
 
 #include "ProjectMars/Nation/State.h"
 
+#include "Logging/StructuredLog.h"
+#include "ProjectMars/Delegates/StateDelegateController.h"
 #include "ProjectMars/Economy/EconomyController.h"
 
 UState::UState()
 {
-	// Constructor
+	// StateDelegateController
+	StateDelegateController = NewObject<UStateDelegateController>();
+
+	// EconomyController
 	EconomyController = NewObject<UEconomyController>();
+	EconomyController->SubscribeToDelegateEvents(StateDelegateController);
+}
+
+void UState::SetupDelegateEvents(UDelegateController* DelegateControllerVar)
+{
+	DelegateControllerVar->OnMonthlyUpdate.AddDynamic(this, &UState::OnMonthlyUpdate);
 }
 
 UEconomyController* UState::GetEconomyController() const
@@ -20,4 +31,10 @@ UState* UState::SetEconomyController(UEconomyController* EconomyControllerVar)
 {
 	this->EconomyController = EconomyControllerVar;
 	return this;
+}
+
+void UState::OnMonthlyUpdate()
+{
+	StateDelegateController->OnStateMonthlyUpdate.Broadcast();
+	UE_LOGFMT(LogTemp, Warning, "State monthly update");
 }

--- a/Source/ProjectMars/Nation/State.h
+++ b/Source/ProjectMars/Nation/State.h
@@ -7,6 +7,7 @@
 #include "State.generated.h"
 
 class UEconomyController;
+class UDelegateController;
 
 // A class to represent a state such as the Roman Republic or Carthage
 UCLASS()
@@ -18,14 +19,29 @@ public:
 	UState();
 
 	UFUNCTION()
+	void SetupDelegateEvents(UDelegateController* DelegateControllerVar);
+
+	UFUNCTION()
+	void OnMonthlyUpdate();
+
+	// Getters
+	UFUNCTION()
 	UEconomyController* GetEconomyController() const;
 	
+	// Setters
 	UFUNCTION()
 	UState* SetEconomyController(UEconomyController* EconomyController);
 
 private:
+	// Functions
+
+	
+	// Variables
 	UPROPERTY()
 	UEconomyController* EconomyController;
+
+	UPROPERTY()
+	class UStateDelegateController* StateDelegateController;
 
 	/*UPROPERTY()
 	UTradeManager* TradeManager;*/


### PR DESCRIPTION
This PR adds a `StateDelegateController` which is a child of the `DelegateController`. The `DelegateController` is designed to only have one instance per game, and the `StateDelegateController` is designed to have one instance per State. This separates out responsibility such that the parent class is responsible for general game events affecting all players (both human and AI), and the child class is responsible for controlling state-specific events such as updating a State's economy.

[PM-18](https://samthompson.atlassian.net/browse/PM-18)