### PR TITLE
PM-21: Refactor Structs

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -102,4 +102,5 @@ ManualIPAddress=
 +PropertyRedirects=(OldName="/Script/ProjectMars.ProjectMarsPlayer.EconomyManager",NewName="/Script/ProjectMars.ProjectMarsPlayer.EconomyController")
 +FunctionRedirects=(OldName="/Script/ProjectMars.MarsGameStateBase.SetDelegateManager",NewName="/Script/ProjectMars.MarsGameStateBase.SetDelegateController")
 +FunctionRedirects=(OldName="/Script/ProjectMars.EconomyController.InitialiseEvents",NewName="/Script/ProjectMars.EconomyController.SubscribeToDelegateEvents")
++FunctionRedirects=(OldName="/Script/ProjectMars.State.SetupDelegateEvents",NewName="/Script/ProjectMars.State.SubscribeToDelegateEvents")
 

--- a/Source/ProjectMars/Economy/Data/EconomyData.cpp
+++ b/Source/ProjectMars/Economy/Data/EconomyData.cpp
@@ -1,53 +1,52 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 
 #include "EconomyData.h"
 
-
-FEconomyData::FEconomyData()
+UEconomyData::UEconomyData()
 {
 	Treasury = 0;
 }
 
-int32 FEconomyData::GetTreasury() const
+int32 UEconomyData::GetTreasury() const
 {
 	return Treasury;
 }
 
-FEconomyData* FEconomyData::SetTreasury(const int32 TreasuryVar)
+UEconomyData* UEconomyData::SetTreasury(const int32 TreasuryVar)
 {
 	Treasury = TreasuryVar;
 	return this;
 }
 
-int32 FEconomyData::GetExpenses() const
+int32 UEconomyData::GetExpenses() const
 {
 	return Expenses;
 }
 
-FEconomyData* FEconomyData::SetExpenses(const int32 ExpensesVar)
+UEconomyData* UEconomyData::SetExpenses(const int32 ExpensesVar)
 {
 	this->Expenses = ExpensesVar;
 	return this;
 }
 
-int32 FEconomyData::GetSumOfIncome() const
+int32 UEconomyData::GetSumOfIncome() const
 {
 	return GrossIncome;
 }
 
-FEconomyData* FEconomyData::SetGrossIncome(const int32 GrossIncomeVar)
+UEconomyData* UEconomyData::SetGrossIncome(const int32 GrossIncomeVar)
 {
 	this->GrossIncome = GrossIncomeVar;
 	return this;
 }
 
-int32 FEconomyData::GetNetIncome() const
+int32 UEconomyData::GetNetIncome() const
 {
 	return NetIncome;
 }
 
-FEconomyData* FEconomyData::SetNetIncome(const int32 NetIncomeVar)
+UEconomyData* UEconomyData::SetNetIncome(const int32 NetIncomeVar)
 {
 	this->NetIncome = NetIncomeVar;
 	return this;

--- a/Source/ProjectMars/Economy/Data/EconomyData.h
+++ b/Source/ProjectMars/Economy/Data/EconomyData.h
@@ -1,28 +1,33 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 #pragma once
 
 #include "CoreMinimal.h"
+#include "UObject/Object.h"
 #include "EconomyData.generated.h"
 
-USTRUCT()
-struct PROJECTMARS_API FEconomyData
+/**
+ * This class stores the data relating to a State's economy.
+ */
+UCLASS()
+class PROJECTMARS_API UEconomyData : public UObject
 {
 	GENERATED_BODY()
 
-	FEconomyData();
+public:
+	UEconomyData();
 
+	// Getters
 	int32 GetTreasury() const;
-	FEconomyData* SetTreasury(const int32 TreasuryVar);
-
 	int32 GetExpenses() const;
-	FEconomyData* SetExpenses(const int32 ExpensesVar);
-
 	int32 GetSumOfIncome() const;
-	FEconomyData* SetGrossIncome(const int32 GrossIncomeVar);
-
 	int32 GetNetIncome() const;
-	FEconomyData* SetNetIncome(const int32 NetIncomeVar);
+	
+	// Setters
+	UEconomyData* SetTreasury(const int32 TreasuryVar);
+	UEconomyData* SetExpenses(const int32 ExpensesVar);
+	UEconomyData* SetGrossIncome(const int32 GrossIncomeVar);
+	UEconomyData* SetNetIncome(const int32 NetIncomeVar);
 
 private:
 	int32 Treasury{};

--- a/Source/ProjectMars/Economy/EconomyController.cpp
+++ b/Source/ProjectMars/Economy/EconomyController.cpp
@@ -10,8 +10,9 @@
 
 UEconomyController::UEconomyController()
 {
+	EconomyData = NewObject<UEconomyData>();
+	
 	// Data structs
-	EconomyData = new FEconomyData;
 
 	// Calculators
 	FinanceCalculator = NewObject<UFinanceCalculator>();
@@ -23,22 +24,22 @@ UEconomyController::UEconomyController()
 
 }
 
-FEconomyData* UEconomyController::GetEconomyData() const
+UEconomyData* UEconomyController::GetEconomyData() const
 {
 	return EconomyData;
 }
 
-const TMap<EIncomeType, int32>* UEconomyController::GetIncomeSources() const
+const TMap<EIncomeType, int32>& UEconomyController::GetIncomeSources() const
 {
-	return &IncomeSources;
+	return IncomeSources;
 }
 
-const TMap<EExpenseType, int32>* UEconomyController::GetExpenseSources() const
+const TMap<EExpenseType, int32>& UEconomyController::GetExpenseSources() const
 {
-	return &ExpenseSources;
+	return ExpenseSources;
 }
 
-UEconomyController* UEconomyController::SetEconomyData(FEconomyData* EconomyDataVar)
+UEconomyController* UEconomyController::SetEconomyData(UEconomyData* EconomyDataVar)
 {
 	this->EconomyData = EconomyDataVar;
 	return this;

--- a/Source/ProjectMars/Economy/EconomyController.h
+++ b/Source/ProjectMars/Economy/EconomyController.h
@@ -6,8 +6,6 @@
 #include "UObject/NoExportTypes.h"
 #include "EconomyController.generated.h"
 
-struct FEconomyData;
-
 class UFinanceCalculator;
 class UStateDelegateController;
 
@@ -45,12 +43,18 @@ public:
 	UEconomyController();
 
 	// Getter
-	FEconomyData* GetEconomyData() const;
-	const TMap<EIncomeType, int32>* GetIncomeSources() const;
-	const TMap<EExpenseType, int32>* GetExpenseSources() const;
+	UFUNCTION()
+	UEconomyData* GetEconomyData() const;
+	
+	UFUNCTION()
+	const TMap<EIncomeType, int32>& GetIncomeSources() const;
+	
+	UFUNCTION()
+	const TMap<EExpenseType, int32>& GetExpenseSources() const;
 
 	// Setter
-	UEconomyController* SetEconomyData(FEconomyData* EconomyDataVar);
+	UFUNCTION()
+	UEconomyController* SetEconomyData(UEconomyData* EconomyDataVar);
 	
 	UFUNCTION()
 	void UpdateTreasury();
@@ -63,7 +67,8 @@ private:
 	UFinanceCalculator* FinanceCalculator{ nullptr };
 
 	// Structs
-	FEconomyData* EconomyData{ nullptr };
+	UPROPERTY()
+	UEconomyData* EconomyData;
 
 	// Maps
 	UPROPERTY()

--- a/Source/ProjectMars/Framework/MarsGameStateBase.cpp
+++ b/Source/ProjectMars/Framework/MarsGameStateBase.cpp
@@ -29,6 +29,11 @@ AMarsGameStateBase::AMarsGameStateBase()
 	UStateBuilder* StateBuilder = NewObject<UStateBuilder>();
 	const TMap<FString, UState*>& States = StateBuilder->BuildStates();
 
+	for (const auto& State : States)
+	{
+		State.Value->SubscribeToDelegateEvents(DelegateController);
+	}
+
 	UE_LOGFMT(LogTemp, Log, "Constructing MarsGameStateBase");
 }
 

--- a/Source/ProjectMars/Nation/State.cpp
+++ b/Source/ProjectMars/Nation/State.cpp
@@ -17,7 +17,7 @@ UState::UState()
 	EconomyController->SubscribeToDelegateEvents(StateDelegateController);
 }
 
-void UState::SetupDelegateEvents(UDelegateController* DelegateControllerVar)
+void UState::SubscribeToDelegateEvents(UDelegateController* DelegateControllerVar)
 {
 	DelegateControllerVar->OnMonthlyUpdate.AddDynamic(this, &UState::OnMonthlyUpdate);
 }

--- a/Source/ProjectMars/Nation/State.h
+++ b/Source/ProjectMars/Nation/State.h
@@ -19,7 +19,7 @@ public:
 	UState();
 
 	UFUNCTION()
-	void SetupDelegateEvents(UDelegateController* DelegateControllerVar);
+	void SubscribeToDelegateEvents(UDelegateController* DelegateControllerVar);
 
 	UFUNCTION()
 	void OnMonthlyUpdate();

--- a/Source/ProjectMars/Test/Economy/EconomyControllerTest.cpp
+++ b/Source/ProjectMars/Test/Economy/EconomyControllerTest.cpp
@@ -1,5 +1,6 @@
 ﻿#include "Misc/AutomationTest.h"
 #include "ProjectMars/Economy/EconomyController.h"
+#include "ProjectMars/Economy/Data/EconomyData.h"
 
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FInitialiseIncomeSourcesTest, "ProjectMars.ProjectMars.Test.Economy.InitialiseIncomeSourcesTest",
                                  EAutomationTestFlags::EditorContext | EAutomationTestFlags::EngineFilter)
@@ -9,24 +10,24 @@ bool FInitialiseIncomeSourcesTest::RunTest(const FString& Parameters)
 	{
 		// given
 		const UEconomyController* EconomyController = NewObject<UEconomyController>();
-		const TMap<EIncomeType, int32>* IncomeSourcesMap = EconomyController->GetIncomeSources();
-		const TMap<EExpenseType, int32>* ExpenseSources = EconomyController->GetExpenseSources();
+		const TMap<EIncomeType, int32>& IncomeSourcesMap = EconomyController->GetIncomeSources();
+		const TMap<EExpenseType, int32>& ExpenseSources = EconomyController->GetExpenseSources();
 		
 		// when
 
 		// then
-		TestTrue("Test income sources map correctly initialised", IncomeSourcesMap->Num() == 5);
-		TestTrue(TEXT("Test income sources map correctly initialised"),IncomeSourcesMap->Contains(EIncomeType::Tax));
-		TestTrue(TEXT("Test income sources map correctly initialised"),IncomeSourcesMap->Contains(EIncomeType::Trade));
-		TestTrue(TEXT("Test income sources map correctly initialised"),IncomeSourcesMap->Contains(EIncomeType::Production));
-		TestTrue(TEXT("Test income sources map correctly initialised"),IncomeSourcesMap->Contains(EIncomeType::Loot));
-		TestTrue(TEXT("Test income sources map correctly initialised"),IncomeSourcesMap->Contains(EIncomeType::Slaves));
+		TestTrue("Test income sources map correctly initialised", IncomeSourcesMap.Num() == 5);
+		TestTrue(TEXT("Test income sources map correctly initialised"),IncomeSourcesMap.Contains(EIncomeType::Tax));
+		TestTrue(TEXT("Test income sources map correctly initialised"),IncomeSourcesMap.Contains(EIncomeType::Trade));
+		TestTrue(TEXT("Test income sources map correctly initialised"),IncomeSourcesMap.Contains(EIncomeType::Production));
+		TestTrue(TEXT("Test income sources map correctly initialised"),IncomeSourcesMap.Contains(EIncomeType::Loot));
+		TestTrue(TEXT("Test income sources map correctly initialised"),IncomeSourcesMap.Contains(EIncomeType::Slaves));
 
-		TestTrue("Test income sources map correctly initialised", ExpenseSources->Num() == 4);
-		TestTrue(TEXT("Test income sources map correctly initialised"),ExpenseSources->Contains(EExpenseType::Army));
-		TestTrue(TEXT("Test income sources map correctly initialised"),ExpenseSources->Contains(EExpenseType::Navy));
-		TestTrue(TEXT("Test income sources map correctly initialised"),ExpenseSources->Contains(EExpenseType::Tribute));
-		TestTrue(TEXT("Test income sources map correctly initialised"),ExpenseSources->Contains(EExpenseType::Corruption));
+		TestTrue("Test income sources map correctly initialised", ExpenseSources.Num() == 4);
+		TestTrue(TEXT("Test income sources map correctly initialised"),ExpenseSources.Contains(EExpenseType::Army));
+		TestTrue(TEXT("Test income sources map correctly initialised"),ExpenseSources.Contains(EExpenseType::Navy));
+		TestTrue(TEXT("Test income sources map correctly initialised"),ExpenseSources.Contains(EExpenseType::Tribute));
+		TestTrue(TEXT("Test income sources map correctly initialised"),ExpenseSources.Contains(EExpenseType::Corruption));
 	}
 	return true;
 }


### PR DESCRIPTION
* This feature was originally designed to refactor only methods that return pointers to TMaps and TArrays and instead make them return by const ref. This was implemented.
* I also noticed an issue using Structs where returning them by pointer wasn't working when giving them a UPROPERTY macro. I have refactored this so that EconomyData is now a UObject and not a Struct. My reason for this is that the EconomyData object does not need public access, even if it is designed to just hold data.

[PM-21](https://samthompson.atlassian.net/browse/PM-21)