### PR TITLE
PM-24: Show economic data

### DIFF
--- a/Source/ProjectMars/Economy/EconomyController.cpp
+++ b/Source/ProjectMars/Economy/EconomyController.cpp
@@ -83,11 +83,11 @@ void UEconomyController::InitialiseMonetarySources()
 	
 	for (EIncomeType Type : TEnumRange<EIncomeType>())
 	{
-		IncomeSources.Add(Type, 0);
+		IncomeSources.Add(Type, 500);
 	}
 	for (EExpenseType Type :  TEnumRange<EExpenseType>())
 	{
-		ExpenseSources.Add(Type, 0);
+		ExpenseSources.Add(Type, 250);
 	}
 }
 

--- a/Source/ProjectMars/Economy/EconomyController.h
+++ b/Source/ProjectMars/Economy/EconomyController.h
@@ -42,6 +42,15 @@ class PROJECTMARS_API UEconomyController : public UObject
 public:
 	UEconomyController();
 
+	/*UPROPERTY()
+	int32 StartTreasury{1000};
+	UPROPERTY()
+	int32 StartExpenses{500};
+	UPROPERTY()
+	int32 StartGrossIncome{2000};
+	UPROPERTY()
+	int32 StartNetIncome{};*/
+	
 	// Getter
 	UFUNCTION()
 	UEconomyData* GetEconomyData() const;

--- a/Source/ProjectMars/Framework/MarsGameStateBase.cpp
+++ b/Source/ProjectMars/Framework/MarsGameStateBase.cpp
@@ -27,13 +27,13 @@ AMarsGameStateBase::AMarsGameStateBase()
 
 	// TODO: May remove when needed - this is here for testing purposes
 	UStateBuilder* StateBuilder = NewObject<UStateBuilder>();
-	const TMap<FString, UState*>& States = StateBuilder->BuildStates();
+	States = StateBuilder->BuildStates();
 
 	for (const auto& State : States)
 	{
 		State.Value->SubscribeToDelegateEvents(DelegateController);
 	}
-
+	
 	UE_LOGFMT(LogTemp, Log, "Constructing MarsGameStateBase");
 }
 
@@ -66,6 +66,20 @@ void AMarsGameStateBase::BeginPlay()
 {
 	Super::BeginPlay();
 	UE_LOG(LogTemp, Error, TEXT("TEST VS CODE!"));
+}
+
+UState* AMarsGameStateBase::GetStateForPlayer(FString StateName) const
+{
+	for (const auto& State : States)
+	{
+		if (State.Key == StateName)
+		{
+			UE_LOGFMT(LogTemp, Warning, "State found matching the string string {0}", StateName);
+			return State.Value;
+		}
+	}
+	UE_LOGFMT(LogTemp, Error, "No states in the TMap matched the string {0}", StateName);
+	return nullptr;
 }
 
 void AMarsGameStateBase::Tick(float DeltaSeconds)

--- a/Source/ProjectMars/Framework/MarsGameStateBase.h
+++ b/Source/ProjectMars/Framework/MarsGameStateBase.h
@@ -11,6 +11,7 @@ class AProjectMarsPlayer;
 class AFactionBase;
 class UDelegateController;
 class AFactionManager;
+class UState;
 
 enum class EMonthOfYear;
 
@@ -25,6 +26,12 @@ public:
 	AMarsGameStateBase();
 
 	virtual void BeginPlay() override;
+
+	UFUNCTION()
+	UState* GetStateForPlayer(FString StateName) const;
+
+	UPROPERTY()
+	TMap<FString, UState*> States;
 
 	UFUNCTION()
 	class AProjectMarsPlayer* GetPlayer();

--- a/Source/ProjectMars/Nation/StateBuilder.cpp
+++ b/Source/ProjectMars/Nation/StateBuilder.cpp
@@ -10,7 +10,7 @@ UStateBuilder::UStateBuilder()
 	
 }
 
-const TMap<FString, UState*>& UStateBuilder::BuildStates()
+TMap<FString, UState*>& UStateBuilder::BuildStates()
 {
 	// TODO: The list of states will be defined in a JSON file instead of this array
 	TArray<FString> StateNames { "Rome", "Etruria", "Samnium" };

--- a/Source/ProjectMars/Nation/StateBuilder.h
+++ b/Source/ProjectMars/Nation/StateBuilder.h
@@ -21,7 +21,7 @@ public:
 	UStateBuilder();
 	
 	UFUNCTION()
-	const TMap<FString, UState*>& BuildStates();
+	TMap<FString, UState*>& BuildStates();
 
 	UFUNCTION()
 	const TMap<FString, UState*>& AddState(FString StateName, UState* State);

--- a/Source/ProjectMars/Player/ProjectMarsPlayer.h
+++ b/Source/ProjectMars/Player/ProjectMarsPlayer.h
@@ -33,6 +33,13 @@ public:
 	AProjectMarsPlayer();
 
 	UPROPERTY(EditAnywhere)
+	UEconomyController* EconomyController { nullptr };
+
+	// Each player has a state they control e.g. the Roman Republic or Carthage
+	UPROPERTY(EditAnywhere)
+	UState* State { nullptr };
+
+	UPROPERTY(EditAnywhere)
 	class USceneComponent* RootComp{ nullptr };
 
 	UPROPERTY(EditAnywhere)
@@ -54,12 +61,7 @@ public:
 	void SetFactionName(const EFactionName& FacName);
 
 private:
-	UPROPERTY(EditAnywhere)
-	UEconomyController* EconomyController { nullptr };
 
-	// Each player has a state they control e.g. the Roman Republic or Carthage
-	UPROPERTY(EditAnywhere)
-	UState* State { nullptr };
 	
 protected:
 	
@@ -172,6 +174,9 @@ private:
 	// Pointer to an army
 	UPROPERTY()
 	class AArmy* FactionArmy{ nullptr };
+
+	UFUNCTION()
+	void InitialisePlayerNation();
 public:
 	// Returns the AArmy object that player has clicked on
 	UFUNCTION()

--- a/Source/ProjectMars/UI/BaseHUD.cpp
+++ b/Source/ProjectMars/UI/BaseHUD.cpp
@@ -6,6 +6,7 @@
 #include "Engine.h"
 #include "Components/Button.h"
 #include "Components/TextBlock.h"
+#include "Logging/StructuredLog.h"
 #include "ProjectMars/TimeManagement/TimeManagementComponent.h"
 #include "ProjectMars/Framework/MarsGameStateBase.h"
 #include "ProjectMars/Player/ProjectMarsPlayer.h"
@@ -14,6 +15,7 @@
 #include "Widgets/EconomyWidget.h"
 #include "Widgets/Events/EventPopupWidget.h"
 #include "ProjectMars/Military/Army.h"
+#include "ProjectMars/Economy/Data/EconomyData.h"
 
 #define OUT
 
@@ -49,6 +51,7 @@ void ABaseHUD::DrawHUD()
 	DrawDate();
 	DrawFPS();
 	DrawTooltip();
+	DrawEconomyData(EconomyData);
 
 	if(EventPopupWidget && EventPopupWidget->DecisionButton)
 	{
@@ -64,6 +67,11 @@ void ABaseHUD::DrawHUD()
 void ABaseHUD::SetDateSuffix(const FString& SuffixVal)
 {
 	DateSuffix = SuffixVal;
+}
+
+void ABaseHUD::InitialiseEconomyData(const UEconomyData* EconomyDataVar)
+{
+	EconomyData = EconomyDataVar;
 }
 
 FVector2D ABaseHUD::GetMonitorResolution()
@@ -159,6 +167,24 @@ void ABaseHUD::DrawPlayerTreasury()
 		//BaseGameplayWidget->EconomyText->SetText(FText::FromString(FString::SanitizeFloat(Player->PlayerEconomy.Treasury)));
 		//BaseGameplayWidget->EconomyText->SetText(FText::AsNumber(Player->PlayerFaction->Economics.Treasury));
 	}
+}
+
+void ABaseHUD::DrawEconomyData(const UEconomyData* EconomyDataVar)
+{
+	if (!BaseGameplayWidget)
+	{
+		UE_LOGFMT(LogTemp, Error, "BaseGameplayeWidget is null!");
+	}
+	
+	FString TreasuryText = "Treasury: " + FString::FromInt(EconomyDataVar->GetTreasury());
+	FString ExpensesText = "Expenses: " + FString::FromInt(EconomyDataVar->GetExpenses());
+	FString GrossIncomeText = "GrossIncome: " + FString::FromInt(EconomyDataVar->GetSumOfIncome());
+	FString NetIncomeText = "NetIncome: " + FString::FromInt(EconomyDataVar->GetNetIncome());
+	
+	BaseGameplayWidget->Treasury->SetText(FText::FromString(TreasuryText));
+	BaseGameplayWidget->Expenses->SetText(FText::FromString(ExpensesText));
+	BaseGameplayWidget->GrossIncome->SetText(FText::FromString(GrossIncomeText));
+	BaseGameplayWidget->NetIncome->SetText(FText::FromString(NetIncomeText));
 }
 
 void ABaseHUD::DrawDate()

--- a/Source/ProjectMars/UI/BaseHUD.h
+++ b/Source/ProjectMars/UI/BaseHUD.h
@@ -4,11 +4,13 @@
 
 #include "CoreMinimal.h"
 #include "GameFramework/HUD.h"
+#include "ProjectMars/Economy/Data/EconomyData.h"
 #include "BaseHUD.generated.h"
 
 enum class EMonthOfYear;
 
 class AFactionBase;
+class UEconomyData;
 
 UCLASS()
 class PROJECTMARS_API ABaseHUD : public AHUD
@@ -25,8 +27,14 @@ public:
 	UFUNCTION()
 	void SetDateSuffix(const FString& SuffixVal);
 
+	UFUNCTION()
+	void InitialiseEconomyData(const UEconomyData* EconomyDataVar);
+
 private:
 	FString DateSuffix{};
+
+	UPROPERTY()
+	const UEconomyData* EconomyData{ nullptr };
 
 protected:
 	virtual void BeginPlay() override;
@@ -68,6 +76,8 @@ public:
 
 /* --- ECONOMY --- */
 	void DrawPlayerTreasury();
+
+	void DrawEconomyData(const UEconomyData* EconomyDataVar);
 	
 
 /* --- TIME ---*/

--- a/Source/ProjectMars/UI/Widgets/BaseGameplayWidget.h
+++ b/Source/ProjectMars/UI/Widgets/BaseGameplayWidget.h
@@ -45,6 +45,18 @@ private:
 	UPROPERTY(EditAnywhere, meta = (BindWidget))
 	class UTextBlock* FPSText{ nullptr };
 
+	UPROPERTY(EditAnywhere, meta = (BindWidget))
+	class UTextBlock* Treasury{ nullptr };
+
+	UPROPERTY(EditAnywhere, meta = (BindWidget))
+	class UTextBlock* Expenses{ nullptr };
+
+	UPROPERTY(EditAnywhere, meta = (BindWidget))
+	class UTextBlock* GrossIncome{ nullptr };
+
+	UPROPERTY(EditAnywhere, meta = (BindWidget))
+	class UTextBlock* NetIncome{ nullptr };
+
 public:
 	void ShowTooltip(UUserWidget* Widget);
 };


### PR DESCRIPTION
* Show economic data in the outliner in the UI.
* This ticket introduces/highlights a lot of tech debt that needs addressing. This will be fixed in future tickets.

[PM-24](https://samthompson.atlassian.net/browse/PM-24)