### PR TITLE
PM-32: Implement turn-based system

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -113,4 +113,5 @@ ManualIPAddress=
 +FunctionRedirects=(OldName="/Script/ProjectMars.NationBuilder.GetStates",NewName="/Script/ProjectMars.NationBuilder.GetNations")
 +PropertyRedirects=(OldName="/Script/ProjectMars.NationBuilder.States",NewName="/Script/ProjectMars.NationBuilder.Nations")
 +PropertyRedirects=(OldName="/Script/ProjectMars.MarsGameStateBase.States",NewName="/Script/ProjectMars.MarsGameStateBase.Nations")
++FunctionRedirects=(OldName="/Script/ProjectMars.TurnController.StartTurn",NewName="/Script/ProjectMars.TurnController.StartNewTurn")
 

--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -90,6 +90,7 @@ DoubleClickTime=0.200000
 +ActionMappings=(ActionName="Carthage",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=Y)
 +ActionMappings=(ActionName="Money",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=SpaceBar)
 +ActionMappings=(ActionName="PauseGame",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=SpaceBar)
++ActionMappings=(ActionName="Enter",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=Enter)
 +AxisMappings=(AxisName="MoveForward",Scale=1.000000,Key=W)
 +AxisMappings=(AxisName="MoveRight",Scale=1.000000,Key=D)
 +AxisMappings=(AxisName="MoveRight",Scale=-1.000000,Key=A)
@@ -102,4 +103,19 @@ DefaultInputComponentClass=/Script/EnhancedInput.EnhancedInputComponent
 DefaultTouchInterface=/Engine/MobileResources/HUD/DefaultVirtualJoysticks.DefaultVirtualJoysticks
 -ConsoleKeys=Tilde
 +ConsoleKeys=Tilde
+
+[/Script/EnhancedInput.EnhancedInputDeveloperSettings]
+UserSettingsClass=/Script/EnhancedInput.EnhancedInputUserSettings
+DefaultPlayerMappableKeyProfileClass=/Script/EnhancedInput.EnhancedPlayerMappableKeyProfile
+DefaultWorldInputClass=/Script/EnhancedInput.EnhancedPlayerInput
+bSendTriggeredEventsWhenInputIsFlushed=True
+bEnableUserSettings=False
+EnhancedInput.EnableDefaultMappingContexts=True
+EnhancedInput.OnlyTriggerLastActionInChord=True
+bLogOnDeprecatedConfigUsed=True
+bEnableWorldSubsystem=False
+EnhancedInput.bShouldLogAllWorldSubsystemInputs=False
+
+[/Script/InputEditor.EnhancedInputEditorProjectSettings]
+DefaultEditorInputClass=/Script/EnhancedInput.EnhancedPlayerInput
 

--- a/Source/ProjectMars/Controllers/AIControllerBase.h
+++ b/Source/ProjectMars/Controllers/AIControllerBase.h
@@ -13,5 +13,8 @@ UCLASS()
 class PROJECTMARS_API AAIControllerBase : public AAIController
 {
 	GENERATED_BODY()
+
+public:
+	const bool bIsPlayerController{ false };
 	
 };

--- a/Source/ProjectMars/Controllers/BasePlayerController.cpp
+++ b/Source/ProjectMars/Controllers/BasePlayerController.cpp
@@ -1,9 +1,12 @@
 // Fill out your copyright notice in the Description page of Project Settings.
 
 
-#include "ProjectMars/Controllers/BasePlayerController.h"
+#include "BasePlayerController.h"
 
 #include "Logging/StructuredLog.h"
+#include "ProjectMars/Delegates/DelegateController.h"
+#include "ProjectMars/Delegates/NationDelegateController.h"
+#include "ProjectMars/Nation/Nation.h"
 #include "ProjectMars/Player/ProjectMarsPlayer.h"
 #include "ProjectMars/UI/BaseHUD.h"
 
@@ -13,17 +16,24 @@ ABasePlayerController::ABasePlayerController()
 	bEnableMouseOverEvents = true;
 	bEnableClickEvents = true;
 
+	NationDelegateController = NewObject<UNationDelegateController>();
+
 	// This is experimental, I think this sets a new HUD for the player
 	if (false)
 	{
 		const TSubclassOf<ABaseHUD> ClientHUD;
 		ClientSetHUD(ClientHUD);
 	}
+	
+	bMyTurn = false;
+	TurnNumber = 0;
 }
 
 void ABasePlayerController::SetupInputComponent()
 {
 	Super::SetupInputComponent();
+
+	InputComponent->BindAction("Enter", IE_Released, this, &ABasePlayerController::OnEnter);
 	
 	InputComponent->BindAction("LeftMouseClick", IE_Released, this, &ABasePlayerController::OnLMBClick);
 	InputComponent->BindAction("RightMouseClick", IE_Pressed, this, &ABasePlayerController::OnRMBClick);
@@ -31,6 +41,26 @@ void ABasePlayerController::SetupInputComponent()
 	// Player Pawn Movement
 	InputComponent->BindAxis("MoveForward", this, &ABasePlayerController::MovePlayerPawnForwardOrBack);
 	InputComponent->BindAxis("GameSpeed", this, &ABasePlayerController::MovePlayerPawnRightOrLeft);
+}
+
+void ABasePlayerController::SubscribeToDelegates(UDelegateController* DelegateControllerVar)
+{
+	DelegateControllerVar->OnChangeTurnOwner.AddDynamic(this, &ABasePlayerController::CheckForMyTurn);
+	DelegateControllerVar->OnStartNewTurn.AddDynamic(this, &ABasePlayerController::StartNewTurn);
+}
+
+ABasePlayerController* ABasePlayerController::SetDelegateController(UDelegateController* DelegateControllerVar)
+{
+	DelegateController = DelegateControllerVar;
+	return this;
+}
+
+ABasePlayerController* ABasePlayerController::SetNation(UNation* NationVar)
+{
+	Nation = NationVar;
+	Nation->SetFactionTag("ROM");
+	UE_LOGFMT(LogTemp, Warning, "Player nation: ROM");
+	return this;
 }
 
 void ABasePlayerController::MovePlayerPawnForwardOrBack(float Val)
@@ -79,8 +109,35 @@ void ABasePlayerController::OnRMBClick()
 	PlayerPawn->IssueMoveArmyOrder();
 }
 
+void ABasePlayerController::OnEnter()
+{
+	// TODO: Add if-statement to check if player is owner of turn
+	DelegateController->OnEndTurn.Broadcast();
+}
+
 void ABasePlayerController::InitialisePointers()
 {
 	PlayerPawn = Cast<AProjectMarsPlayer>(GetPawn());
 	HUD = Cast<ABaseHUD>(GetHUD());
+}
+
+void ABasePlayerController::CheckForMyTurn(const FString& CurrentTurnOwnerTag)
+{
+	if (!Nation)
+	{
+		UE_LOGFMT(LogTemp, Error, "Nation is null");
+	} 
+
+	UE_LOGFMT(LogTemp, Warning, "Current turn owner: {0}", CurrentTurnOwnerTag);
+	if (CurrentTurnOwnerTag == Nation->GetFactionTag())
+	{
+		bMyTurn = true;
+		return;
+	}
+	bMyTurn = false;
+}
+
+void ABasePlayerController::StartNewTurn(const int32 TurnNumberVar)
+{
+	TurnNumber = TurnNumberVar;
 }

--- a/Source/ProjectMars/Controllers/BasePlayerController.h
+++ b/Source/ProjectMars/Controllers/BasePlayerController.h
@@ -8,6 +8,9 @@
 
 class AProjectMarsPlayer;
 class ABaseHUD;
+class UNation;
+class UDelegateController;
+class UNationDelegateController;
 
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnRMBPressed);
 
@@ -23,8 +26,22 @@ public:
 	virtual void Tick(float DeltaSeconds) override;
 	virtual void SetupInputComponent() override;
 
+	UFUNCTION()
+	void SubscribeToDelegates(UDelegateController* DelegateControllerVar);
+
+	// Getters
+
+	// Setters
+	UFUNCTION()
+	ABasePlayerController* SetDelegateController(UDelegateController* DelegateControllerVar);
+
+	UFUNCTION()
+	ABasePlayerController* SetNation(UNation* NationVar);
+
 	// Properties
 	FOnRMBPressed OnRMBPressed;
+	
+	const bool bIsPlayerController { true };
 	
 private:
 	// Functions
@@ -41,7 +58,16 @@ private:
 	void OnRMBClick();
 
 	UFUNCTION()
+	void OnEnter();
+
+	UFUNCTION()
 	void InitialisePointers();
+
+	UFUNCTION()
+	void CheckForMyTurn(const FString& CurrentTurnOwnerTag);
+
+	UFUNCTION()
+	void StartNewTurn(const int32 TurnNumberVar);
 	
 	// Properties
 	UPROPERTY(EditAnywhere)
@@ -50,6 +76,20 @@ private:
 	UPROPERTY(EditAnywhere)
 	ABaseHUD* HUD{ nullptr };
 
+	UPROPERTY(EditAnywhere)
+	bool bMyTurn;
+
+	UPROPERTY(EditAnywhere)
+	UNation* Nation{ nullptr };
+
+	UPROPERTY(EditAnywhere)
+	UDelegateController* DelegateController{ nullptr };
+
+	UPROPERTY(EditAnywhere)
+	UNationDelegateController* NationDelegateController{ nullptr };
+
+	UPROPERTY()
+	int32 TurnNumber;
 protected:
 	virtual void BeginPlay() override;
 };

--- a/Source/ProjectMars/Delegates/DelegateController.h
+++ b/Source/ProjectMars/Delegates/DelegateController.h
@@ -9,6 +9,9 @@
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnMonthlyUpdate);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnPlayerInitialisation);
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnAIFactionInitialisation);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnEndTurn);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnChangeTurnOwner, const FString&, CurrentTurnOwner);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnStartNewTurn, const int32, TurnNumber);
 
 /**
  * 
@@ -22,6 +25,9 @@ public:
 	FOnMonthlyUpdate OnMonthlyUpdate;
 	FOnPlayerInitialisation OnPlayerInitialisation;
 	FOnAIFactionInitialisation OnAIFactionInitialisation;
+	FOnEndTurn OnEndTurn;
+	FOnStartNewTurn OnStartNewTurn;
+	FOnChangeTurnOwner OnChangeTurnOwner;
 
 private:
 	

--- a/Source/ProjectMars/Delegates/NationDelegateController.cpp
+++ b/Source/ProjectMars/Delegates/NationDelegateController.cpp
@@ -1,7 +1,7 @@
 ﻿// Fill out your copyright notice in the Description page of Project Settings.
 
 
-#include "StateDelegateController.h"
+#include "NationDelegateController.h"
 
 UNationDelegateController::UNationDelegateController()
 {

--- a/Source/ProjectMars/Delegates/NationDelegateController.h
+++ b/Source/ProjectMars/Delegates/NationDelegateController.h
@@ -4,9 +4,9 @@
 
 #include "CoreMinimal.h"
 #include "DelegateController.h"
-#include "StateDelegateController.generated.h"
+#include "NationDelegateController.generated.h"
 
-DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnNationMonthlyUpdate);
+DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnNewTurn);
 
 /**
  * 
@@ -19,5 +19,5 @@ class PROJECTMARS_API UNationDelegateController : public UDelegateController
 public:
 	UNationDelegateController();
 	
-	FOnNationMonthlyUpdate OnNationMonthlyUpdate;
+	FOnNewTurn OnNewTurn;
 };

--- a/Source/ProjectMars/Economy/EconomyController.cpp
+++ b/Source/ProjectMars/Economy/EconomyController.cpp
@@ -5,7 +5,7 @@
 
 #include "FinanceCalculator.h"
 #include "Logging/StructuredLog.h"
-#include "ProjectMars/Delegates/StateDelegateController.h"
+#include "..\Delegates\NationDelegateController.h"
 #include "ProjectMars/Economy/Data/EconomyData.h"
 
 UEconomyController::UEconomyController()
@@ -68,11 +68,9 @@ void UEconomyController::UpdateTreasury()
 	UE_LOGFMT(LogTemp, Display, "Treasury updated!");
 }
 
-void UEconomyController::SubscribeToDelegateEvents(UNationDelegateController* StateDelegateController)
+void UEconomyController::SubscribeToDelegateEvents(UNationDelegateController* NationDelegateControllerVar)
 {
-	StateDelegateController->OnNationMonthlyUpdate.AddDynamic(this, &UEconomyController::UpdateTreasury);
-	
-	UE_LOGFMT(LogTemp, Display, "Delegate manager is INITIALISED!");
+	// Subscribe to delegates
 }
 
 // Initialises map of income sources with enum keys and values set to 0 by default

--- a/Source/ProjectMars/Economy/EconomyController.h
+++ b/Source/ProjectMars/Economy/EconomyController.h
@@ -69,7 +69,7 @@ public:
 	void UpdateTreasury();
 
 	UFUNCTION()
-	void SubscribeToDelegateEvents(UNationDelegateController* StateDelegateController);
+	void SubscribeToDelegateEvents(UNationDelegateController* NationDelegateControllerVar);
 
 private:
 	UPROPERTY()

--- a/Source/ProjectMars/Framework/MarsGameStateBase.cpp
+++ b/Source/ProjectMars/Framework/MarsGameStateBase.cpp
@@ -4,10 +4,12 @@
 #include "MarsGameStateBase.h"
 
 #include "Logging/StructuredLog.h"
+#include "ProjectMars/Controllers/BasePlayerController.h"
 #include "ProjectMars/Player/ProjectMarsPlayer.h"
 #include "ProjectMars/Delegates/DelegateController.h"
 #include "ProjectMars/Nation/Nation.h"
 #include "ProjectMars/Nation/NationBuilder.h"
+#include "ProjectMars/Turns/TurnController.h"
 
 AMarsGameStateBase::AMarsGameStateBase()
 {
@@ -16,14 +18,14 @@ AMarsGameStateBase::AMarsGameStateBase()
 
 	DelegateController = NewObject<UDelegateController>();
 
-	// TODO: May remove when needed - this is here for testing purposes
-	UNationBuilder* NationBuilder = NewObject<UNationBuilder>();
-	Nations = NationBuilder->BuildNations();
-
-	for (const auto& Nation : Nations)
-	{
-		Nation.Value->SubscribeToDelegateEvents(DelegateController);
-	}
+	// Turn Controller
+	TurnController = NewObject<UTurnController>();
+	TurnController->SetMarsGameStateBase(this);
+	TurnController->SetDelegateController(DelegateController);
+	TurnController->SubscribeToDelegates(DelegateController);
+	
+	InitialiseFactionTags();
+	BuildNations();
 	
 	UE_LOGFMT(LogTemp, Log, "Constructing MarsGameStateBase");
 }
@@ -31,6 +33,11 @@ AMarsGameStateBase::AMarsGameStateBase()
 void AMarsGameStateBase::AddPlayerToPlayerArray(AProjectMarsPlayer* ProjectMarsPlayer)
 {
 	AllPlayers.Add(ProjectMarsPlayer);
+	ABasePlayerController* PlayerController = Cast<ABasePlayerController>(ProjectMarsPlayer->GetController());
+	ensure(PlayerController);
+	PlayerController->SetDelegateController(DelegateController);
+	PlayerController->SubscribeToDelegates(DelegateController);
+	PlayerController->SetNation(*Nations.Find("ROM"));
 	UE_LOGFMT(LogTemp, Display, "Added player to player array");
 }
 
@@ -39,6 +46,7 @@ void AMarsGameStateBase::BeginPlay()
 {
 	Super::BeginPlay();
 	UE_LOG(LogTemp, Error, TEXT("TEST VS CODE!"));
+	// TODO: For development purposes - gives the developer a nation
 }
 
 void AMarsGameStateBase::Tick(float DeltaSeconds)
@@ -54,4 +62,26 @@ UDelegateController* AMarsGameStateBase::GetDelegateController() const
 void AMarsGameStateBase::SetDelegateController(UDelegateController* DelegateControllerVar)
 {
 	DelegateController = DelegateControllerVar;
+}
+
+// Creates array of all faction tags - the order of this array is the order of the turn owners turn
+void AMarsGameStateBase::InitialiseFactionTags()
+{
+	// TODO: Have array populated by JSON file of all faction tags
+	
+	FactionTags.Add("ROM");
+	FactionTags.Add("SAM");
+	FactionTags.Add("CAR");
+	TurnController->SetFactionTags(FactionTags);
+}
+
+// Creates all the nations in the game
+void AMarsGameStateBase::BuildNations()
+{
+	UNationBuilder* NationBuilder = NewObject<UNationBuilder>();
+	Nations = NationBuilder->BuildNations(FactionTags);
+	for (const auto& Nation : Nations)
+	{
+		Nation.Value->SubscribeToDelegateEvents(DelegateController);
+	}
 }

--- a/Source/ProjectMars/Framework/MarsGameStateBase.h
+++ b/Source/ProjectMars/Framework/MarsGameStateBase.h
@@ -10,6 +10,7 @@
 class AProjectMarsPlayer;
 class UDelegateController;
 class UNation;
+class UTurnController;
 
 UCLASS()
 class PROJECTMARS_API AMarsGameStateBase : public AGameStateBase
@@ -34,6 +35,14 @@ public:
 	void SetDelegateController(UDelegateController* ptr);
 
 private:
+	// Functions
+	UFUNCTION()
+	void InitialiseFactionTags();
+
+	UFUNCTION()
+	void BuildNations();
+	
+	// Properties
 	UPROPERTY(EditAnywhere)
 	TMap<FString, UNation*> Nations;
 	
@@ -42,6 +51,12 @@ private:
 	
 	UPROPERTY(EditAnywhere)
 	UDelegateController* DelegateController{ nullptr };
+
+	UPROPERTY(EditAnywhere)
+	UTurnController* TurnController{ nullptr };
+
+	UPROPERTY(EditAnywhere)
+	TArray<FString> FactionTags;
 
 protected:
 	virtual void Tick(float DeltaSeconds) override;

--- a/Source/ProjectMars/Nation/Nation.cpp
+++ b/Source/ProjectMars/Nation/Nation.cpp
@@ -4,7 +4,7 @@
 #include "Nation.h"
 
 #include "Logging/StructuredLog.h"
-#include "ProjectMars/Delegates/StateDelegateController.h"
+#include "..\Delegates\NationDelegateController.h"
 #include "ProjectMars/Economy/EconomyController.h"
 
 UNation::UNation()
@@ -15,11 +15,24 @@ UNation::UNation()
 	// EconomyController
 	EconomyController = NewObject<UEconomyController>();
 	EconomyController->SubscribeToDelegateEvents(NationDelegateController);
+	
+	FactionTag = "NONE";
 }
 
 UEconomyController* UNation::GetEconomyController() const
 {
 	return EconomyController;
+}
+
+AProjectMarsPlayer* UNation::GetOwningPlayer() const
+{
+	return OwningPlayer;
+}
+
+UNation* UNation::SetOwningPlayer(AProjectMarsPlayer* PlayerVar)
+{
+	OwningPlayer = PlayerVar;
+	return this;
 }
 
 UNation* UNation::SetEconomyController(UEconomyController* EconomyControllerVar)
@@ -28,8 +41,13 @@ UNation* UNation::SetEconomyController(UEconomyController* EconomyControllerVar)
 	return this;
 }
 
-void UNation::OnMonthlyUpdate()
+UNation* UNation::SetFactionTag(const FString& FactionTagVar)
 {
-	NationDelegateController->OnNationMonthlyUpdate.Broadcast();
-	UE_LOGFMT(LogTemp, Display, "State monthly update");
+	FactionTag = FactionTagVar;
+	return this;
+}
+
+const FString& UNation::GetFactionTag() const
+{
+	return FactionTag;
 }

--- a/Source/ProjectMars/Nation/Nation.h
+++ b/Source/ProjectMars/Nation/Nation.h
@@ -9,6 +9,7 @@
 
 class UEconomyController;
 class UDelegateController;
+class AProjectMarsPlayer;
 
 // A class to represent a state such as the Roman Republic or Carthage
 UCLASS()
@@ -18,27 +19,44 @@ class PROJECTMARS_API UNation : public UCustomObject
 
 public:
 	UNation();
-	
-	virtual void OnMonthlyUpdate() override;
+
+	// Functions
+	UFUNCTION()
+	UNation* SetFactionTag(const FString& FactionTagVar);
+
+	UFUNCTION()
+	const FString& GetFactionTag() const;
 
 	// Getters
 	UFUNCTION()
 	UEconomyController* GetEconomyController() const;
+
+	UFUNCTION()
+	AProjectMarsPlayer* GetOwningPlayer() const;
 	
 	// Setters
 	UFUNCTION()
 	UNation* SetEconomyController(UEconomyController* EconomyController);
+
+	UFUNCTION()
+	UNation* SetOwningPlayer(AProjectMarsPlayer* PlayerVar);
 
 private:
 	// Functions
 
 	
 	// Variables
-	UPROPERTY()
+	UPROPERTY(EditAnywhere)
 	UEconomyController* EconomyController;
 
-	UPROPERTY()
+	UPROPERTY(EditAnywhere)
 	class UNationDelegateController* NationDelegateController;
+
+	UPROPERTY(EditAnywhere)
+	FString FactionTag;
+
+	UPROPERTY(EditAnywhere)
+	AProjectMarsPlayer* OwningPlayer{ nullptr };
 
 	/*UPROPERTY()
 	UTradeManager* TradeManager;*/

--- a/Source/ProjectMars/Nation/NationBuilder.cpp
+++ b/Source/ProjectMars/Nation/NationBuilder.cpp
@@ -10,16 +10,16 @@ UNationBuilder::UNationBuilder()
 	
 }
 
-TMap<FString, UNation*>& UNationBuilder::BuildNations()
+TMap<FString, UNation*>& UNationBuilder::BuildNations(const TArray<FString>& FactionTagsVar)
 {
 	// TODO: The list of nations will be defined in a JSON file instead of this array
-	TArray<FString> NationNames { "Rome", "Etruria", "Samnium" };
-
-	constexpr int32 NumOfNations = 3;
-	for (int32 i = 0; i < NumOfNations; i++)
+	int32 Index = 0;
+	for (const auto Tag : FactionTagsVar)
 	{
 		UNation* Nation = NewObject<UNation>();
-		Nations.Add(NationNames[i], Nation);
+		Nation->SetFactionTag(Tag);
+		Nations.Add(FactionTagsVar[Index], Nation);
+		Index++;
 	}
 	return Nations;
 }

--- a/Source/ProjectMars/Nation/NationBuilder.h
+++ b/Source/ProjectMars/Nation/NationBuilder.h
@@ -21,7 +21,7 @@ public:
 	UNationBuilder();
 	
 	UFUNCTION()
-	TMap<FString, UNation*>& BuildNations();
+	TMap<FString, UNation*>& BuildNations(const TArray<FString>& FactionTagsVar);
 
 	UFUNCTION()
 	const TMap<FString, UNation*>& AddNation(const FString& NationNameVar, UNation* NationVar);

--- a/Source/ProjectMars/Player/ProjectMarsPlayer.h
+++ b/Source/ProjectMars/Player/ProjectMarsPlayer.h
@@ -46,6 +46,10 @@ public:
 	UFUNCTION()
 	void IssueMoveArmyOrder();
 
+	// Getters
+
+	// Setters
+
 private:
 	// Properties
 	UPROPERTY(EditAnywhere)

--- a/Source/ProjectMars/Turns/TurnController.cpp
+++ b/Source/ProjectMars/Turns/TurnController.cpp
@@ -1,0 +1,79 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "TurnController.h"
+
+#include "Logging/StructuredLog.h"
+#include "ProjectMars/Delegates/DelegateController.h"
+#include "ProjectMars/Framework/MarsGameStateBase.h"
+
+UTurnController::UTurnController()
+{
+	CurrentTurnOwnerIndex = 0;
+	TurnNumber = 1;
+}
+
+void UTurnController::EndTurn()
+{
+	UE_LOGFMT(LogTemp, Display, "Turn controller calling ENDTURN");
+	BroadcastCurrentTurnOwner(ChangeCurrentTurnOwner());
+}
+
+// Broadcasts an event that a new turn has started
+void UTurnController::StartNewTurn(const int32 TurnNumberVar)
+{
+	DelegateController->OnStartNewTurn.Broadcast(TurnNumberVar);
+}
+
+int32 UTurnController::UpdateTurnNumber()
+{
+	const int32 NewTurnNumber = TurnNumber++;
+	StartNewTurn(NewTurnNumber);
+	return NewTurnNumber;
+}
+
+int32 UTurnController::GetTurnNumber() const
+{
+	return TurnNumber;
+}
+
+UTurnController* UTurnController::SetDelegateController(UDelegateController* DelegateControllerVar)
+{
+	DelegateController = DelegateControllerVar;
+	return this;
+}
+
+UTurnController* UTurnController::SetMarsGameStateBase(AMarsGameStateBase* MarsGameStateBaseVar)
+{
+	MarsGameStateBase = MarsGameStateBaseVar;
+	return this;
+}
+
+UTurnController* UTurnController::SetFactionTags(const TArray<FString>& FactionTagsVar)
+{
+	FactionTags = FactionTagsVar;
+	return this;
+}
+
+void UTurnController::SubscribeToDelegates(UDelegateController* DelegateControllerVar)
+{
+	DelegateControllerVar->OnEndTurn.AddDynamic(this, &UTurnController::EndTurn);
+}
+
+// Returns the tag of the current turn owner
+const FString& UTurnController::ChangeCurrentTurnOwner()
+{
+	if (CurrentTurnOwnerIndex + 1 > FactionTags.Num())
+	{
+		CurrentTurnOwnerIndex = 0;
+		UpdateTurnNumber();
+	}
+	const FString& Tag = FactionTags[CurrentTurnOwnerIndex];
+	CurrentTurnOwnerIndex++;
+	return Tag;
+}
+
+void UTurnController::BroadcastCurrentTurnOwner(const FString& CurrentTurnOwnerVar)
+{
+	DelegateController->OnChangeTurnOwner.Broadcast(CurrentTurnOwnerVar);
+}

--- a/Source/ProjectMars/Turns/TurnController.h
+++ b/Source/ProjectMars/Turns/TurnController.h
@@ -1,0 +1,72 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
+#include "TurnController.generated.h"
+
+class UDelegateController;
+class AMarsGameStateBase;
+
+/**
+ * Contains logic and data relating to the start and end turn processes
+ */
+UCLASS()
+class PROJECTMARS_API UTurnController : public UObject
+{
+	GENERATED_BODY()
+
+public:
+	UTurnController();
+	
+	UFUNCTION()
+	void EndTurn();
+
+	UFUNCTION()
+	void StartNewTurn(const int32 TurnNumberVar);
+
+	UFUNCTION()
+	int32 UpdateTurnNumber();
+
+	// Getters
+	UFUNCTION()
+	int32 GetTurnNumber() const;
+
+	// Setters
+	UFUNCTION()
+	UTurnController* SetDelegateController(UDelegateController* DelegateControllerVar);
+
+	UFUNCTION()
+	UTurnController* SetMarsGameStateBase(AMarsGameStateBase* MarsGameStateBaseVar);
+
+	UFUNCTION()
+	UTurnController* SetFactionTags(const TArray<FString>& FactionTagsVar);
+
+	UFUNCTION()
+	void SubscribeToDelegates(UDelegateController* DelegateControllerVar);
+	
+private:
+	// Functions
+	UFUNCTION()
+	const FString& ChangeCurrentTurnOwner();
+
+	UFUNCTION()
+	void BroadcastCurrentTurnOwner(const FString& CurrentTurnOwnerVar);
+	
+	// Properties
+	UPROPERTY(EditAnywhere)
+	UDelegateController* DelegateController{ nullptr };
+
+	UPROPERTY(EditAnywhere)
+	int32 TurnNumber{};
+
+	UPROPERTY(EditAnywhere)
+	AMarsGameStateBase* MarsGameStateBase{ nullptr };
+
+	UPROPERTY(EditAnywhere)
+	TArray<FString> FactionTags;
+
+	UPROPERTY(EditAnywhere)
+	int32 CurrentTurnOwnerIndex;
+};


### PR DESCRIPTION
* The turn-based system is owned and controlled by the TurnController, which itself is owned by the game state. The idea is to make things such as turn number, season, owner of the current turn etc be server authorititive.
* New delegates have been introduced to build out the turn-based system.
* The player controller is updated with information about the turn. The controller then runs a check to see if it is the owner of the turn by comparing the string passed to it by the turn controller against it's own nation's tag.

[PM-32](https://samthompson.atlassian.net/browse/PM-33)